### PR TITLE
improve out-of-box watchers for Laravel

### DIFF
--- a/browser-sync.js
+++ b/browser-sync.js
@@ -9,7 +9,7 @@ if (filesdir === "") {
 
 module.exports = {
 
-    files: [docroot],
+    files: [docroot, "app", "resources"],
     ignore: ["node_modules", filesdir, "vendor"],
     open: false,
     ui: false,

--- a/browser-sync.js
+++ b/browser-sync.js
@@ -9,7 +9,7 @@ if (filesdir === "") {
 
 module.exports = {
 
-    files: [docroot, "app", "resources"],
+    files: [docroot, "app", "resources/views/**/*.php"],
     ignore: ["node_modules", filesdir, "vendor"],
     open: false,
     ui: false,


### PR DESCRIPTION
This PR improves browsersync watched files for Laravel projects. 

It adds out-of-the-box support for the following directories:
- "app"
- "resources/views/**/*.php" (blade templates)

## Tested

- Laravel 9 
- Drupal 9

Fixes #9