### PR TITLE
Fix #ddev-generated problems with HEAD, fixes #12

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -2,7 +2,7 @@ name: tests
 on:
   pull_request:
   push:
-    branches: [ master, main ]
+    branches: [ main ]
 
   schedule:
   - cron: '01 07 * * *'
@@ -29,8 +29,8 @@ jobs:
 
     strategy:
       matrix:
-        ddev_version: [stable, edge, HEAD]
-#        ddev_version: [PR]
+        ddev_version: [stable, HEAD]
+#        ddev_version: [stable, edge, HEAD, PR]
       fail-fast: false
 
     runs-on: ubuntu-20.04

--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ ddev restart
 ddev browsersync
 ```
 
-The new `ddev browsersync` global command runs browsersync inside the web container and provides a 
+The new `ddev browsersync` global command runs browsersync inside the web container and provides a
 link ("External") to the browsersync-update URL. Use the URL in the output that says something like "External: http://d9.ddev.site:3000".
 
 ## What does this add-on do and add?

--- a/docker-compose.browsersync.yaml
+++ b/docker-compose.browsersync.yaml
@@ -1,3 +1,4 @@
+#ddev-generated
 # Override the web container's standard HTTP_EXPOSE and HTTPS_EXPOSE
 # This is to expose the browsersync port.
 version: '3.6'

--- a/install.yaml
+++ b/install.yaml
@@ -14,7 +14,7 @@ project_files:
 
 
 global_files:
-  - commands
+  - commands/web/browsersync
 
 
 post_install_actions:

--- a/install.yaml
+++ b/install.yaml
@@ -2,13 +2,14 @@ name: ddev-browsersync
 
 pre_install_actions:
 - | 
+  #ddev-nodisplay
   if ! ( ddev debug capabilities 2>/dev/null | grep multiple-dockerfiles >/dev/null 2>&1 ) ; then
     echo "This add-on requires DDEV v1.19.3 or higher, please upgrade." && exit 2
   fi
 
 project_files:
   - docker-compose.browsersync.yaml
-  - web-build
+  - web-build/Dockerfile.ddev-browsersync
   - browser-sync.js
 
 


### PR DESCRIPTION
ddev HEAD was broken in tests last night due to Dockerfile.example not having #ddev-generated in it.

* Install specific files instead of whole web-build directory to work around this. Probably better anyway.
* Limit github actions tests slightly (don't need edge)
* Add #ddev-nodisplay to the capabilities check